### PR TITLE
Add support for Ollama and Hugging Face via Langchain + LiteLLM

### DIFF
--- a/.env.huggingface.template
+++ b/.env.huggingface.template
@@ -1,0 +1,9 @@
+model="huggingface/meta-llama/Llama-3.1-8B-Instruct"
+HF_TOKEN=<Huggingface token>
+
+# To use a Hugging Face model, specify both the provider and model you want to use in the following format:
+# huggingface/<provider>/<hf_org_or_user>/<hf_model>
+# Where <hf_org_or_user>/<hf_model> is the Hugging Face model ID and <provider> is the inference provider.
+
+#List of models 
+# https://endpoints.huggingface.co/catalog?task=text-generation

--- a/.env.huggingface.template
+++ b/.env.huggingface.template
@@ -1,9 +1,2 @@
-model="huggingface/meta-llama/Llama-3.1-8B-Instruct"
+model_name="hf-meta-llama"
 HF_TOKEN=<Huggingface token>
-
-# To use a Hugging Face model, specify both the provider and model you want to use in the following format:
-# huggingface/<provider>/<hf_org_or_user>/<hf_model>
-# Where <hf_org_or_user>/<hf_model> is the Hugging Face model ID and <provider> is the inference provider.
-
-#List of models 
-# https://endpoints.huggingface.co/catalog?task=text-generation

--- a/.env.ollama.template
+++ b/.env.ollama.template
@@ -1,0 +1,2 @@
+model="ollama/llama3"
+OLLAMA_HOST=http://localhost:11434

--- a/.env.ollama.template
+++ b/.env.ollama.template
@@ -1,2 +1,2 @@
-model="ollama/llama3"
+model_name="ollama-local-llama3"
 OLLAMA_HOST=http://localhost:11434

--- a/.env.openai.template
+++ b/.env.openai.template
@@ -1,0 +1,2 @@
+model=gpt-4o
+OPENAI_API_KEY=<open ai api key>

--- a/.env.openai.template
+++ b/.env.openai.template
@@ -1,2 +1,2 @@
-model=gpt-4o
+model_name="openai-gpt-4o"
 OPENAI_API_KEY=<open ai api key>

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ pipenv install python-dotenv
 
 ### Running the Application
 
-Before running the application, you need to setup a .env file based on the provided env templates.
+Before running the application, you need to setup a .env file based on the provided env templates. The env templates have a model_name variable which can be chosen from the list of models mentioned in llm-config.yaml.
 
 #### To run with OpenAI
-You need to drop a valid OpenAI API key in the .env file (that you can create by copying the env.list template). Note: you need access to **GPT-4** or **GPT-4-Turbo**, as GPT-3.5-Turbo can't use tools reliably.
+You need to drop a valid OpenAI API key in the .env file (that you can create by copying the .env.openai.template). Note: We have limited use to **GPT-4** as GPT-3.5-Turbo can't use tools reliably.
 
 #### To run with Models from HuggingFace
 You need to drop a valid HuggingFace Token in the .env file (that you can create by copying the .env.huggingface.template). Note: It is possible that you may not see reasonable results with the chosen models yet.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,25 @@ pipenv install python-dotenv
 
 ### Running the Application
 
-Before running the application, you need to drop a valid OpenAI API key in the .env file (that you can create by copying the env.list template). Note: you need access to **GPT-4** or **GPT-4-Turbo**, as GPT-3.5-Turbo can't use tools reliably.
+Before running the application, you need to setup a .env file based on the provided env templates.
 
-To run the application:
+#### To run with OpenAI
+You need to drop a valid OpenAI API key in the .env file (that you can create by copying the env.list template). Note: you need access to **GPT-4** or **GPT-4-Turbo**, as GPT-3.5-Turbo can't use tools reliably.
+
+#### To run with Models from HuggingFace
+You need to drop a valid HuggingFace Token in the .env file (that you can create by copying the .env.huggingface.template). Note: It is possible that you may not see reasonable results with the chosen models yet.
+
+#### To run using ollama locally
+- Create a .env by copying .env.ollama.template.
+- Install [Ollama](https://github.com/ollama/ollama)
+- ollama pull llama3:latest
+
+Note: Please note that while this local mode is great for getting a taste of the application. It is possible that you may not see reasonable results with these yet.
+
+#### To run the application:
 
 ```sh
-streamlit run main.py
+python -m streamlit run main.py
 ```
 
 ### Docker Image

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To get started, you need to set up your Python environment by following these st
 python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-pipenv install python-dotenv
+pip install python-dotenv
 ```
 
 ### Running the Application

--- a/env.list
+++ b/env.list
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=

--- a/llm-config.yaml
+++ b/llm-config.yaml
@@ -1,0 +1,19 @@
+default_model: gpt-4-1106-preview
+models:
+  - model_name: openai-gpt4
+    model: gpt-4-1106-preview
+
+  - model_name: openai-gpt-4o
+    model: gpt-4o
+
+  - model_name: ollama-local-llama3
+    model: "ollama/llama3"
+
+  - model_name: ollama-local-mistral
+    model: "ollama/mistral"
+
+  - model_name: ollama-local-llava
+    model: "ollama/llava:7b"
+
+  - model_name: hf-meta-llama
+    model: "huggingface/meta-llama/Llama-3.1-8B-Instruct"

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 import langchain
 import streamlit as st
+import os
 from dotenv import load_dotenv
 from langchain.agents import ConversationalChatAgent, AgentExecutor
 from langchain.callbacks import StreamlitCallbackHandler
-from langchain.chat_models import ChatOpenAI
+from langchain_litellm import ChatLiteLLM
 from langchain.memory import ConversationBufferMemory
 from langchain.memory.chat_message_histories import StreamlitChatMessageHistory
 from langchain.agents import initialize_agent
@@ -59,8 +60,8 @@ for idx, msg in enumerate(msgs.messages):
 if prompt := st.chat_input(placeholder="Show my recent transactions"):
     st.chat_message("user").write(prompt)
 
-    llm = ChatOpenAI(
-        model_name="gpt-4-1106-preview",
+    llm = ChatLiteLLM(
+        model=os.getenv("model"),
         temperature=0, streaming=True
     )
     tools = tools

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from langchain.agents import initialize_agent
 from langchain.callbacks import get_openai_callback
 
 from tools import get_current_user_tool, get_recent_transactions_tool
-from utils import display_instructions, display_logo
+from utils import display_instructions, display_logo, fetch_model_config
 
 load_dotenv()
 
@@ -59,9 +59,9 @@ for idx, msg in enumerate(msgs.messages):
 
 if prompt := st.chat_input(placeholder="Show my recent transactions"):
     st.chat_message("user").write(prompt)
-
+    
     llm = ChatLiteLLM(
-        model=os.getenv("model"),
+        model=fetch_model_config(),
         temperature=0, streaming=True
     )
     tools = tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
-langchain==0.0.306
-openai==0.28.1
+langchain~=0.3.25
+openai~=1.78.0
+langchain-litellm~=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit
 langchain~=0.3.25
 openai~=1.78.0
-langchain-litellm~=0.2.0
+langchain-litellm==0.2.0
+langchain-community

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 import streamlit as st
 import base64
+import yaml
+import os
 
 def display_instructions():
     # Markdown with some basic CSS styles for the box
@@ -67,3 +69,17 @@ def display_logo():
     """
     # Display the HTML in the sidebar
     st.sidebar.markdown(html_string, unsafe_allow_html=True)
+
+def _load_llm_config():
+    with open('llm-config.yaml', 'r') as f:
+        yaml_data = yaml.load(f, Loader=yaml.SafeLoader)
+    return yaml_data
+
+def fetch_model_config():
+    chosen_model_name = os.getenv("model_name")
+    llm_config = _load_llm_config()
+    for model_config in llm_config.get("models"):
+        if chosen_model_name == model_config.get("model_name"):
+            return model_config.get("model")
+    else:
+        return llm_config.get("default_model")


### PR DESCRIPTION
Description:

This PR introduces support for running the app with local models using [Ollama](https://ollama.com/) and hosted models via [Hugging Face](https://huggingface.co/), alongside the existing GPT-4 support. To enable this, I have used LiteLLM, allowing seamless switching between model providers.

Changes:

Introduced langchain-litellm
Added support for:
Local models via Ollama
Hosted models via Hugging Face Inference API
Updated README.md with setup instructions and usage examples
Added example .env templates for each provider configuration

This sets the foundation for more flexible and cost-effective LLM deployments while retaining compatibility with GPT-4o.